### PR TITLE
Move ASAN CI job to macOS

### DIFF
--- a/.github/workflows/build-ci.yml
+++ b/.github/workflows/build-ci.yml
@@ -7,6 +7,7 @@ jobs:
     uses: ./.github/workflows/macos-build.yml
     with:
       repository: HuangJian/librime
+      ref: ci-build-librime-qjs # The branch, tag or SHA to checkout
       rime_plugins: ${{ github.repository }}@${{ github.ref_name }}
       enable_coverage: false
 

--- a/.github/workflows/linux-build.yml
+++ b/.github/workflows/linux-build.yml
@@ -71,35 +71,3 @@ jobs:
         env:
           CMAKE_GENERATOR: Ninja
 
-  asan:
-    runs-on: ubuntu-24.04
-    env:
-      CC: clang-22
-      CXX: clang++-22
-      RIME_PLUGINS: ${{ inputs.rime_plugins }}
-    steps:
-      - name: Checkout last commit
-        uses: actions/checkout@v4
-        with:
-          repository: ${{ inputs.repository }}
-          ref: ${{ inputs.ref }}
-
-      - name: Install dependency
-        run: ./action-install-linux.sh
-
-      - name: Install Rime plugins
-        run: ./action-install-plugins-linux.sh
-
-      - name: Install clang-22
-        run: |
-          wget https://apt.llvm.org/llvm.sh
-          chmod +x llvm.sh
-          sudo ./llvm.sh 22
-
-      - name: Detect Memory Leak
-        run: |
-          make clean
-          make test-debug CFLAGS="-g -fsanitize=address" LDFLAGS="-fsanitize=address"
-          ASAN_OPTIONS=detect_leaks=1 ./plugins/qjs/build/librime-qjs-tests
-        env:
-          CMAKE_GENERATOR: Ninja

--- a/.github/workflows/macos-build.yml
+++ b/.github/workflows/macos-build.yml
@@ -6,6 +6,10 @@ on:
         default: HuangJian/librime
         required: false
         type: string
+      ref:
+        default: ${{ github.ref_name }}
+        required: false
+        type: string
       rime_plugins:
         default: ${{ github.repository }}@${{ github.ref_name }}
         required: false
@@ -48,13 +52,17 @@ jobs:
         uses: actions/checkout@v5
         with:
           repository: ${{ inputs.repository }}
+          ref: ${{ inputs.ref }}
           submodules: recursive
 
       - name: Configure build environment
         run: |
           brew install llvm ninja
           echo "CMAKE_GENERATOR=Ninja"  >> $GITHUB_ENV
-          echo "$(brew --prefix llvm)/bin" >> $GITHUB_PATH
+          LLVM_PATH=$(brew --prefix llvm)/bin
+          echo "$LLVM_PATH" >> $GITHUB_PATH
+          echo "CC=$LLVM_PATH/clang" >> $GITHUB_ENV
+          echo "CXX=$LLVM_PATH/clang++" >> $GITHUB_ENV
           echo git_ref_name="$(git describe --always)" >> $GITHUB_ENV
           
 
@@ -126,13 +134,17 @@ jobs:
         uses: actions/checkout@v5
         with:
           repository: ${{ inputs.repository }}
+          ref: ${{ inputs.ref }}
           submodules: recursive
 
       - name: Configure build environment
         run: |
           brew install llvm ninja
           echo "CMAKE_GENERATOR=Ninja"  >> $GITHUB_ENV
-          echo "$(brew --prefix llvm)/bin" >> $GITHUB_PATH
+          LLVM_PATH=$(brew --prefix llvm)/bin
+          echo "$LLVM_PATH" >> $GITHUB_PATH
+          echo "CC=$LLVM_PATH/clang" >> $GITHUB_ENV
+          echo "CXX=$LLVM_PATH/clang++" >> $GITHUB_ENV
           echo git_ref_name="$(git describe --always)" >> $GITHUB_ENV
 
       - name: Configure build variant
@@ -199,3 +211,63 @@ jobs:
         with:
           name: coverage-report-macOS
           path: coverage_report
+
+  asan:
+    runs-on: macos-13
+    env:
+      boost_version: 1.89.0
+      BOOST_ROOT: ${{ github.workspace }}/deps/boost-1.89.0
+      RIME_PLUGINS: ${{ inputs.rime_plugins }}
+    steps:
+      - name: Checkout last commit
+        uses: actions/checkout@v5
+        with:
+          repository: ${{ inputs.repository }}
+          ref: ${{ inputs.ref }}
+          submodules: recursive
+
+      - name: Configure build environment
+        run: |
+          brew install llvm ninja
+          echo "CMAKE_GENERATOR=Ninja"  >> $GITHUB_ENV
+          LLVM_PATH=$(brew --prefix llvm)/bin
+          echo "$LLVM_PATH" >> $GITHUB_PATH
+          echo "CC=$LLVM_PATH/clang" >> $GITHUB_ENV
+          echo "CXX=$LLVM_PATH/clang++" >> $GITHUB_ENV
+          echo git_ref_name="$(git describe --always)" >> $GITHUB_ENV
+
+      - name: Configure build variant
+        run: |
+          echo BUILD_UNIVERSAL=1 >> $GITHUB_ENV
+
+      - name: Install Boost
+        run: ./install-boost.sh
+
+      - name: Check submodules
+        run: git submodule > submodule-status
+
+      - name: Cache dependencies
+        id: cache-deps
+        uses: actions/cache@v4
+        with:
+          path: |
+            bin
+            include
+            lib
+            share
+          key: ${{ runner.os }}-${{ runner.arch }}-deps-${{ hashFiles('submodule-status') }}
+
+      - name: Build dependencies
+        if: steps.cache-deps.outputs.cache-hit != 'true'
+        run: make deps
+
+      - name: Install Rime plugins
+        run: ./action-install-plugins-macos.sh
+
+      - name: Detect Memory Leak
+        run: |
+          make clean
+          make test-debug CFLAGS="-g -fsanitize=address" LDFLAGS="-fsanitize=address"
+          ASAN_OPTIONS=detect_leaks=1 ./plugins/qjs/build/librime-qjs-tests
+        env:
+          CMAKE_GENERATOR: Ninja

--- a/.github/workflows/release-ci.yml
+++ b/.github/workflows/release-ci.yml
@@ -16,6 +16,7 @@ jobs:
     uses: ./.github/workflows/macos-build.yml
     with:
       repository: HuangJian/librime
+      ref: ci-build-librime-qjs # The branch, tag or SHA to checkout
       rime_plugins: ${{ github.repository }}@${{ github.ref_name }}
       build_type: "${{ github.ref == 'refs/heads/main' && 'Nightly' || 'Release' }}"
       enable_coverage: true


### PR DESCRIPTION
The AddressSanitizer (ASAN) CI job has been moved from Ubuntu to macOS to centralize testing on the macOS platform. Since LeakSanitizer (LSAN) is not currently supported on Apple Silicon (ARM64) runners (macos-14/15), the job is explicitly configured to run on `macos-13` (Intel). 

Additionally, the `macos-build.yml` workflow was updated to accept a `ref` parameter, ensuring that PRs and branch-specific builds check out the intended code. This parameter is now correctly passed from the main `build-ci.yml` and `release-ci.yml` workflows. 

To ensure the correct compiler is used for sanitization, `CC` and `CXX` are now explicitly exported to point to the Clang binaries provided by Homebrew's LLVM package.

---
*PR created automatically by Jules for task [11521204638176594406](https://jules.google.com/task/11521204638176594406) started by @HuangJian*